### PR TITLE
stop socket code cleanup, tomcat.destroy() when stopping

### DIFF
--- a/tomcat6x/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/Tomcat6xServer.groovy
+++ b/tomcat6x/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/Tomcat6xServer.groovy
@@ -23,6 +23,7 @@ package org.gradle.api.plugins.tomcat.embedded
 class Tomcat6xServer implements TomcatServer {
     final embedded
     def context
+    Boolean stopped
 
     public Tomcat6xServer() {
         Class serverClass = loadClass('org.apache.catalina.startup.Embedded')
@@ -184,11 +185,14 @@ class Tomcat6xServer implements TomcatServer {
 
     @Override
     void start() {
+        this.setStopped false
         embedded.start()
     }
 
     @Override
     void stop() {
+        this.setStopped true
         embedded.stop()
+        embedded.destroy()
     }
 }

--- a/tomcat7x/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/Tomcat7xServer.groovy
+++ b/tomcat7x/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/Tomcat7xServer.groovy
@@ -25,6 +25,7 @@ import java.lang.reflect.Constructor
 class Tomcat7xServer implements TomcatServer {
     final tomcat
     def context
+    Boolean stopped
 
     public Tomcat7xServer() {
         Class serverClass = loadClass('org.apache.catalina.startup.Tomcat')
@@ -126,11 +127,14 @@ class Tomcat7xServer implements TomcatServer {
 
     @Override
     void start() {
+        this.setStopped false
         tomcat.start()
     }
 
     @Override
     void stop() {
+        this.setStopped true
         tomcat.stop()
+        tomcat.destroy()
     }
 }


### PR DESCRIPTION
Before this change when tomcat was stopped (in non daemon mode) System.exit(1) was called causing the gradle daemon to exit although we only want
tomcat to stop. I think this was done because the ports were not released by tomcat because tomcat.destroy was not called when
stopping.

Right now we call tomcat.destroy() after stopping thus releasing the resources and allow gradle to run in daemon mode.
When tomcat runs in daemon mode it shouldn't be treated differently from when it runs in non daemon mode so it is stopped by the same mechanism.

This should fix a couple of issues from the tracker regarding stopping tomcat.
