### PR TITLE
implemented AJP connector setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The Tomcat plugin defines the following convention properties:
 
 * `httpPort`: The TCP port which Tomcat should listen for HTTP requests on (defaults to `8080`).
 * `httpsPort`: The TCP port which Tomcat should listen for HTTPS requests on (defaults to `8443`).
+* `ajpPort`: The TCP port which Tomcat should listen for AJP requests on (defaults to `8009`).
 * `stopPort`: The TCP port which Tomcat should listen for admin requests on (defaults to `8081`).
 * `stopKey`: The key to pass to Tomcat when requesting it to stop (defaults to `null`).
 * `enableSSL`: Determines whether the HTTPS connector should be created (defaults to `false`).
@@ -83,6 +84,7 @@ The Tomcat plugin defines the following convention properties:
 * `keystorePass`: The keystore password to use for SSL, if enabled.
 * `httpProtocol`: The HTTP protocol handler class name to be used (defaults to `org.apache.coyote.http11.Http11Protocol`).
 * `httpsProtocol`: The HTTPS protocol handler class name to be used (defaults to `org.apache.coyote.http11.Http11Protocol`).
+* `ajpProtocol`: The AJP protocol handler class name to be used (defaults to `org.apache.coyote.ajp.AjpProtocol`).
 
 These properties are provided by a TomcatPluginConvention convention object. Furthermore, you can define the following
 optional properties:
@@ -144,11 +146,13 @@ The convention properties can be overridden by system properties:
 
 * `tomcat.http.port`: Overrides the convention property `httpPort`.
 * `tomcat.https.port`: Overrides the convention property `httpsPort`.
+* `tomcat.ajp.port`: Overrides the convention property `ajpPort`.
 * `tomcat.stop.port`: Overrides the convention property `stopPort`.
 * `tomcat.stop.key`: Overrides the convention property `stopKey`.
 * `tomcat.enable.ssl`: Overrides the convention property `enableSSL`.
 * `tomcat.http.protocol`: Overrides the convention property `httpProtocol`.
 * `tomcat.https.protocol`: Overrides the convention property `httpsProtocol`.
+* `tomcat.ajp.protocol`: Overrides the convention property `ajpProtocol`.
 
 ## FAQ
 

--- a/embedded/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/TomcatServer.groovy
+++ b/embedded/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/TomcatServer.groovy
@@ -30,6 +30,7 @@ interface TomcatServer {
     void createContext(String fullContextPath, String webAppPath)
     void configureContainer()
     void configureHttpConnector(int port, String uriEncoding, String protocolHandlerClassName)
+    void configureAjpConnector(int port, String uriEncoding, String protocolHandlerClassName)
     void configureHttpsConnector(int port, String uriEncoding, String protocolHandlerClassName, String keystore, String keyPassword)
     void configureDefaultWebXml(File webDefaultXml)
     void setConfigFile(URL configFile)

--- a/plugin/src/main/groovy/org/gradle/api/plugins/tomcat/AbstractTomcatRunTask.groovy
+++ b/plugin/src/main/groovy/org/gradle/api/plugins/tomcat/AbstractTomcatRunTask.groovy
@@ -61,6 +61,8 @@ abstract class AbstractTomcatRunTask extends DefaultTask {
     @InputFile @Optional File keystoreFile
     String keystorePass
     File outputFile
+    Integer ajpPort
+    String ajpProtocol
 
     abstract void setWebApplicationContext()
 
@@ -214,6 +216,7 @@ abstract class AbstractTomcatRunTask extends DefaultTask {
 
             getServer().configureContainer()
             getServer().configureHttpConnector(getHttpPort(), getURIEncoding(), getHttpProtocol())
+            getServer().configureAjpConnector(getAjpPort(), getURIEncoding(), getAjpProtocol())
 
             if(getEnableSSL()) {
                 if(!getKeystoreFile()) {
@@ -341,5 +344,15 @@ abstract class AbstractTomcatRunTask extends DefaultTask {
     String getHttpsProtocol() {
         String httpsProtocolHandlerClassNameSystemProperty = TomcatSystemProperty.httpsProtocolHandlerClassName
         httpsProtocolHandlerClassNameSystemProperty ?: httpsProtocol
+    }
+    
+    Integer getAjpPort() {
+      Integer ajpPortSystemProperty = TomcatSystemProperty.ajpPort
+      ajpPortSystemProperty ?: ajpPort
+    }
+    
+    String getAjpProtocol() {
+      String ajpProtocolHandlerClassNameSystemProperty = TomcatSystemProperty.ajpProtocolHandlerClassName
+      ajpProtocolHandlerClassNameSystemProperty ?: ajpProtocol
     }
 }

--- a/plugin/src/main/groovy/org/gradle/api/plugins/tomcat/TomcatPlugin.groovy
+++ b/plugin/src/main/groovy/org/gradle/api/plugins/tomcat/TomcatPlugin.groovy
@@ -40,6 +40,9 @@ class TomcatPlugin implements Plugin<Project> {
     static final String HTTP_PROTOCOL = 'httpProtocol'
     static final String HTTPS_PROTOCOL = 'httpsProtocol'
     static final String TOMCAT_CONFIGURATION_NAME = 'tomcat'
+    static final String AJP_PORT_CONVENTION = 'ajpPort'
+    static final String AJP_PROTOCOL_CONVENTION = 'ajpProtocol'
+    
 
     @Override
     void apply(Project project) {
@@ -77,6 +80,8 @@ class TomcatPlugin implements Plugin<Project> {
         tomcatTask.conventionMapping.map(ENABLE_SSL_CONVENTION) { tomcatConvention.enableSSL }
         tomcatTask.conventionMapping.map(HTTP_PROTOCOL) { tomcatConvention.httpProtocol }
         tomcatTask.conventionMapping.map(HTTPS_PROTOCOL) { tomcatConvention.httpsProtocol }
+        tomcatTask.conventionMapping.map(AJP_PORT_CONVENTION) { tomcatConvention.ajpPort }
+        tomcatTask.conventionMapping.map(AJP_PROTOCOL_CONVENTION) { tomcatConvention.ajpProtocol }
     }
 
     private void configureTomcatRun(final Project project) {

--- a/plugin/src/main/groovy/org/gradle/api/plugins/tomcat/TomcatPluginConvention.groovy
+++ b/plugin/src/main/groovy/org/gradle/api/plugins/tomcat/TomcatPluginConvention.groovy
@@ -22,14 +22,17 @@ package org.gradle.api.plugins.tomcat
  */
 class TomcatPluginConvention {
     final static String DEFAULT_PROTOCOL_HANDLER = 'org.apache.coyote.http11.Http11Protocol'
+    final static String DEFAULT_AJP_PROTOCOL_HANDLER = 'org.apache.coyote.ajp.AjpProtocol'
 
     Integer httpPort = 8080
     Integer httpsPort = 8443
     Integer stopPort = 8081
+    Integer ajpPort = 8009
     String stopKey
     Boolean enableSSL = false
     String httpProtocol = DEFAULT_PROTOCOL_HANDLER
     String httpsProtocol = DEFAULT_PROTOCOL_HANDLER
+    String ajpProtocol = DEFAULT_AJP_PROTOCOL_HANDLER
     TomcatJasperConvention jasper = new TomcatJasperConvention()
 
     def jasper(Closure closure) {

--- a/plugin/src/main/groovy/org/gradle/api/plugins/tomcat/TomcatSystemProperty.groovy
+++ b/plugin/src/main/groovy/org/gradle/api/plugins/tomcat/TomcatSystemProperty.groovy
@@ -30,6 +30,8 @@ final class TomcatSystemProperty {
     static final String ENABLE_SSL_SYSPROPERTY = 'tomcat.enable.ssl'
     static final String HTTP_PROTOCOL_SYSPROPERTY = 'tomcat.http.protocol'
     static final String HTTPS_PROTOCOL_SYSPROPERTY = 'tomcat.https.protocol'
+    static final String AJP_PROTOCOL_SYSPROPERTY = 'tomcat.ajp.protocol'
+    static final String AJP_PORT_SYSPROPERTY = 'tomcat.ajp.port'
 
     private TomcatSystemProperty() {}
 
@@ -92,9 +94,29 @@ final class TomcatSystemProperty {
         String httpProtocolHandlerClassName = System.getProperty(HTTP_PROTOCOL_SYSPROPERTY)
         httpProtocolHandlerClassName ?: null
     }
-
+    
     static String getHttpsProtocolHandlerClassName() {
         String httpsProtocolHandlerClassName = System.getProperty(HTTPS_PROTOCOL_SYSPROPERTY)
         httpsProtocolHandlerClassName ?: null
     }
+    
+    static String getAjpProtocolHandlerClassName() {
+      String ajpProtocolHandlerClassName = System.getProperty(AJP_PROTOCOL_SYSPROPERTY)
+      ajpProtocolHandlerClassName ?: null
+    }
+    
+    static Integer getAjpPort() {
+      String ajpPortSystemProperty = System.getProperty(AJP_PORT_SYSPROPERTY)
+
+      if(ajpPortSystemProperty) {
+          try {
+              return ajpPortSystemProperty.toInteger()
+          }
+          catch(NumberFormatException e) {
+              throw new InvalidUserDataException("Bad AJP port provided as system property: ${ajpPortSystemProperty}", e)
+          }
+      }
+
+      null
+  }
 }

--- a/plugin/src/test/groovy/org/gradle/api/plugins/tomcat/TomcatPluginConventionTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/api/plugins/tomcat/TomcatPluginConventionTest.groovy
@@ -41,6 +41,16 @@ class TomcatPluginConventionTest {
     void testGetHttpPortForDefaultValue() {
         assert pluginConvention.httpPort == 8080
     }
+    
+    @Test
+    void testGetAjpProtocolForDefaultValue() {
+      assert pluginConvention.ajpProtocol == 'org.apache.coyote.ajp.AjpProtocol'
+    }
+    
+    @Test
+    void testGetAjpPortForDefaultValue() {
+      assert pluginConvention.ajpPort == 8009
+    }
 
     @Test
     void testGetStopPortForDefaultValue() {

--- a/plugin/src/test/groovy/org/gradle/api/plugins/tomcat/TomcatPluginTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/api/plugins/tomcat/TomcatPluginTest.groovy
@@ -72,6 +72,8 @@ class TomcatPluginTest {
         assert task.reloadable == true
         assert task.webAppClasspath == project.tasks.getByName(WarPlugin.WAR_TASK_NAME).classpath
         assert task.webAppSourceDirectory == project.convention.getPlugin(WarPluginConvention.class).webAppDir
+        assert task.ajpPort == 8009
+        assert task.ajpProtocol == 'org.apache.coyote.ajp.AjpProtocol'
     }
 
     @Test

--- a/plugin/src/test/groovy/org/gradle/api/plugins/tomcat/TomcatSystemPropertyTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/api/plugins/tomcat/TomcatSystemPropertyTest.groovy
@@ -34,6 +34,8 @@ class TomcatSystemPropertyTest {
         System.clearProperty(TomcatSystemProperty.ENABLE_SSL_SYSPROPERTY)
         System.clearProperty(TomcatSystemProperty.HTTP_PROTOCOL_SYSPROPERTY)
         System.clearProperty(TomcatSystemProperty.HTTPS_PROTOCOL_SYSPROPERTY)
+        System.clearProperty(TomcatSystemProperty.AJP_PORT_SYSPROPERTY);
+        System.clearProperty(TomcatSystemProperty.AJP_PROTOCOL_SYSPROPERTY);
     }
 
     @Test
@@ -135,5 +137,33 @@ class TomcatSystemPropertyTest {
     void testGetHttpsProtocolHandlerClassNameForValidExistingProperty() {
         System.setProperty(TomcatSystemProperty.HTTPS_PROTOCOL_SYSPROPERTY, 'org.apache.coyote.http11.Http11NioProtocol')
         assert TomcatSystemProperty.getHttpsProtocolHandlerClassName() == 'org.apache.coyote.http11.Http11NioProtocol'
+    }
+    
+    @Test
+    void testGetAjpProtocolHandlerClassNameForNonExistingProperty() {
+      assert TomcatSystemProperty.getAjpProtocolHandlerClassName() == null
+    }
+    
+    @Test
+    void testGetAjpProtocolHandlerClassNameForValidExistingProperty() {
+      System.setProperty(TomcatSystemProperty.AJP_PROTOCOL_SYSPROPERTY, 'org.apache.coyote.ajp.AjpAprProtocol')
+      assert TomcatSystemProperty.getAjpProtocolHandlerClassName() == 'org.apache.coyote.ajp.AjpAprProtocol'
+    }
+    
+    @Test
+    void testGetAjpPortForNonExistingProperty() {
+        assert TomcatSystemProperty.getAjpPort() == null
+    }
+
+    @Test
+    void testGetAjpPortForValidExistingProperty() {
+        System.setProperty(TomcatSystemProperty.AJP_PORT_SYSPROPERTY, "8109")
+        assert TomcatSystemProperty.getAjpPort() == 8109
+    }
+    
+    @Test(expected = InvalidUserDataException.class)
+    void testGetAjpPortForInvalidExistingProperty() {
+        System.setProperty(TomcatSystemProperty.AJP_PORT_SYSPROPERTY, "xxx")
+        TomcatSystemProperty.getAjpPort()
     }
 }

--- a/tomcat6x/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/Tomcat6xServer.groovy
+++ b/tomcat6x/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/Tomcat6xServer.groovy
@@ -88,6 +88,14 @@ class Tomcat6xServer implements TomcatServer {
     }
 
     @Override
+    void configureAjpConnector(int port, String uriEncoding, String protocolHandlerClassName) {
+        def ajpConnector = createConnector(protocolHandlerClassName, uriEncoding)
+        ajpConnector.port = port
+        
+        tomcat.service.addConnector ajpConnector
+    }
+    
+    @Override
     void configureHttpsConnector(int port, String uriEncoding, String protocolHandlerClassName, String keystore, String keyPassword) {
         def httpsConnector = createConnector(port, uriEncoding, protocolHandlerClassName)
         httpsConnector.scheme = 'https'

--- a/tomcat7x/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/Tomcat7xServer.groovy
+++ b/tomcat7x/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/Tomcat7xServer.groovy
@@ -90,7 +90,15 @@ class Tomcat7xServer implements TomcatServer {
         tomcat.service.removeConnector tomcat.connector
         tomcat.service.addConnector httpConnector
      }
-
+    
+    @Override
+    void configureAjpConnector(int port, String uriEncoding, String protocolHandlerClassName) {
+        def ajpConnector = createConnector(protocolHandlerClassName, uriEncoding)
+        ajpConnector.port = port
+        
+        tomcat.service.addConnector ajpConnector
+    }
+    
     @Override
     void configureHttpsConnector(int port, String uriEncoding, String protocolHandlerClassName, String keystore, String keyPassword) {
         def httpsConnector = createConnector(protocolHandlerClassName, uriEncoding)


### PR DESCRIPTION
Hi Benjamin,

I've implemented the possibility to add and configure an AJP connector. What do you think? I've tested it using the tomcatRun task and the configured default values (port 8009, org.apache.coyote.ajp.AjpProtocol). Switching to the org.apache.coyote.ajp.AjpAprProtocol leads to an exception (missing ARP/native library). I'm not sure how to add this library to the gradle process.

Best, 

Moritz
