### PR TITLE
1: Added capability for user to specify truststoreFile, truststorePass a...

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,13 @@ The Tomcat plugin defines the following convention properties:
 * `enableSSL`: Determines whether the HTTPS connector should be created (defaults to `false`).
 * `keystoreFile`: The keystore file to use for SSL, if enabled (by default, a keystore will be generated).
 * `keystorePass`: The keystore password to use for SSL, if enabled.
+* `truststoreFile`: The truststore file to use for SSL, if enabled.
+* `truststorePass`: The truststore password to use for SSL, if enabled.
+* `clientAuth`: The clientAuth setting to use, values may be: `true`, `false` or `want` (defaults to `false`).
 * `httpProtocol`: The HTTP protocol handler class name to be used (defaults to `org.apache.coyote.http11.Http11Protocol`).
 * `httpsProtocol`: The HTTPS protocol handler class name to be used (defaults to `org.apache.coyote.http11.Http11Protocol`).
+
+Note: `keystoreFile` and `truststoreFile` each require an instance of a `File` object e.g. `file("/path/my.file")`
 
 These properties are provided by a TomcatPluginConvention convention object. Furthermore, you can define the following
 optional properties:

--- a/embedded/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/TomcatServer.groovy
+++ b/embedded/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/TomcatServer.groovy
@@ -30,7 +30,7 @@ interface TomcatServer {
     void createContext(String fullContextPath, String webAppPath)
     void configureContainer()
     void configureHttpConnector(int port, String uriEncoding, String protocolHandlerClassName)
-    void configureHttpsConnector(int port, String uriEncoding, String protocolHandlerClassName, String keystore, String keyPassword)
+    void configureHttpsConnector(int port, String uriEncoding, String protocolHandlerClassName, String keystore, String keyPassword, String truststore, String trustPassword, String clientAuth)
     void configureDefaultWebXml(File webDefaultXml)
     void setConfigFile(URL configFile)
     void start()

--- a/plugin/src/test/groovy/org/gradle/api/plugins/tomcat/TomcatRunTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/api/plugins/tomcat/TomcatRunTest.groovy
@@ -143,7 +143,7 @@ class TomcatRunTest {
     void testValidateConfigurationForEnabledSSLButOnlyKeystoreFileConfigured() {
         File webAppSourceDir = createWebAppSourceDirectory()
         tomcatRun.setWebAppSourceDirectory webAppSourceDir
-        tomcatRun.setKeystoreFile createKeystoreFile()
+        tomcatRun.setKeystoreFile createFile(testDir, "keystore.jks")
         tomcatRun.setHttpProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
         tomcatRun.setHttpsProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
         tomcatRun.enableSSL = true
@@ -165,7 +165,7 @@ class TomcatRunTest {
     void testValidateConfigurationForEnabledSSLForKeystoreFileAndPasswordConfigured() {
         File webAppSourceDir = createWebAppSourceDirectory()
         tomcatRun.setWebAppSourceDirectory webAppSourceDir
-        tomcatRun.setKeystoreFile createKeystoreFile()
+        tomcatRun.setKeystoreFile createFile(testDir, "keystore.jks")
         tomcatRun.setKeystorePass 'pwd'
         tomcatRun.setHttpProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
         tomcatRun.setHttpsProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
@@ -174,6 +174,120 @@ class TomcatRunTest {
         assert tomcatRun.getEnableSSL() == true
         assert tomcatRun.getKeystoreFile() == new File(testDir, "keystore.jks")
         assert tomcatRun.getKeystorePass() == 'pwd'
+    }
+    
+    @Test
+    void testValidateConfigurationForEnabledSSLButNoTruststoreConfigured() {
+        File webAppSourceDir = createWebAppSourceDirectory()
+        tomcatRun.setWebAppSourceDirectory webAppSourceDir
+        tomcatRun.setHttpProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.setHttpsProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.enableSSL = true
+        tomcatRun.validateConfiguration()
+        assert tomcatRun.getEnableSSL() == true
+        assert tomcatRun.getTruststoreFile() == null
+        assert tomcatRun.getTruststorePass() == null
+    }
+
+    @Test(expected = InvalidUserDataException.class)
+    void testValidateConfigurationForEnabledSSLButOnlyTruststoreFileConfigured() {
+        File webAppSourceDir = createWebAppSourceDirectory()
+        tomcatRun.setWebAppSourceDirectory webAppSourceDir
+        tomcatRun.setTruststoreFile createFile(testDir, "truststore.jks")
+        tomcatRun.setHttpProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.setHttpsProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.enableSSL = true
+        tomcatRun.validateConfiguration()
+    }
+
+    @Test(expected = InvalidUserDataException.class)
+    void testValidateConfigurationForEnabledSSLButOnlyTruststorePasswordConfigured() {
+        File webAppSourceDir = createWebAppSourceDirectory()
+        tomcatRun.setWebAppSourceDirectory webAppSourceDir
+        tomcatRun.setTruststorePass 'pwd'
+        tomcatRun.setHttpProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.setHttpsProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.enableSSL = true
+        tomcatRun.validateConfiguration()
+    }
+
+    @Test
+    void testValidateConfigurationForEnabledSSLForTruststoreFileAndPasswordConfigured() {
+        File webAppSourceDir = createWebAppSourceDirectory()
+        tomcatRun.setWebAppSourceDirectory webAppSourceDir
+        tomcatRun.setTruststoreFile createFile(testDir, "truststore.jks")
+        tomcatRun.setTruststorePass 'pwd'
+        tomcatRun.setHttpProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.setHttpsProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.enableSSL = true
+        tomcatRun.validateConfiguration()
+        assert tomcatRun.getEnableSSL() == true
+        assert tomcatRun.getTruststoreFile() == new File(testDir, "truststore.jks")
+        assert tomcatRun.getTruststorePass() == 'pwd'
+    }
+    
+    @Test(expected = InvalidUserDataException.class)
+    void testValidateConfigurationForEnabledSSLButIllegalClientAuthValue() {
+        File webAppSourceDir = createWebAppSourceDirectory()
+        tomcatRun.setWebAppSourceDirectory webAppSourceDir
+        tomcatRun.setTruststoreFile createFile(testDir, "truststore.jks")
+        tomcatRun.setTruststorePass 'pwd'
+        tomcatRun.setHttpProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.setHttpsProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.enableSSL = true
+        tomcatRun.clientAuth = "This is not a valid clientAuth value"
+        tomcatRun.validateConfiguration()
+    }
+    
+    @Test
+    void testValidateConfigurationForEnabledSSLAndClientAuthValueFalse() {
+        File webAppSourceDir = createWebAppSourceDirectory()
+        tomcatRun.setWebAppSourceDirectory webAppSourceDir
+        tomcatRun.setTruststoreFile createFile(testDir, "truststore.jks")
+        tomcatRun.setTruststorePass 'pwd'
+        tomcatRun.setHttpProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.setHttpsProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.enableSSL = true
+        tomcatRun.clientAuth = "false"
+        tomcatRun.validateConfiguration()
+        assert tomcatRun.getEnableSSL() == true
+        assert tomcatRun.getTruststoreFile() == new File(testDir, "truststore.jks")
+        assert tomcatRun.getTruststorePass() == 'pwd'
+        assert tomcatRun.clientAuth == "false"
+    }
+    
+    @Test
+    void testValidateConfigurationForEnabledSSLAndClientAuthValueTrue() {
+        File webAppSourceDir = createWebAppSourceDirectory()
+        tomcatRun.setWebAppSourceDirectory webAppSourceDir
+        tomcatRun.setTruststoreFile createFile(testDir, "truststore.jks")
+        tomcatRun.setTruststorePass 'pwd'
+        tomcatRun.setHttpProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.setHttpsProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.enableSSL = true
+        tomcatRun.clientAuth = "true"
+        tomcatRun.validateConfiguration()
+        assert tomcatRun.getEnableSSL() == true
+        assert tomcatRun.getTruststoreFile() == new File(testDir, "truststore.jks")
+        assert tomcatRun.getTruststorePass() == 'pwd'
+        assert tomcatRun.clientAuth == "true"
+    }
+    
+    @Test
+    void testValidateConfigurationForEnabledSSLAndClientAuthValueWant() {
+        File webAppSourceDir = createWebAppSourceDirectory()
+        tomcatRun.setWebAppSourceDirectory webAppSourceDir
+        tomcatRun.setTruststoreFile createFile(testDir, "truststore.jks")
+        tomcatRun.setTruststorePass 'pwd'
+        tomcatRun.setHttpProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.setHttpsProtocol TomcatPluginConvention.DEFAULT_PROTOCOL_HANDLER
+        tomcatRun.enableSSL = true
+        tomcatRun.clientAuth = "want"
+        tomcatRun.validateConfiguration()
+        assert tomcatRun.getEnableSSL() == true
+        assert tomcatRun.getTruststoreFile() == new File(testDir, "truststore.jks")
+        assert tomcatRun.getTruststorePass() == 'pwd'
+        assert tomcatRun.clientAuth == "want"
     }
 
     @Test
@@ -297,14 +411,14 @@ class TomcatRunTest {
         defaultConfigFile
     }
 
-    private File createKeystoreFile() {
-        File keystoreFile = new File(testDir, "keystore.jks")
-        boolean success = keystoreFile.createNewFile()
+    private File createFile(File dir, String filename) {
+        File file = new File(dir, filename)
+        boolean success = file.createNewFile()
 
         if(!success) {
-            fail "Unable to create keystore file"
+            fail "Unable to create file: ${filename} in directory ${dir.canonicalPath}"
         }
 
-        keystoreFile
+        file
     }
 }

--- a/tomcat6x/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/Tomcat6xServer.groovy
+++ b/tomcat6x/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/Tomcat6xServer.groovy
@@ -88,7 +88,7 @@ class Tomcat6xServer implements TomcatServer {
     }
 
     @Override
-    void configureHttpsConnector(int port, String uriEncoding, String protocolHandlerClassName, String keystore, String keyPassword) {
+    void configureHttpsConnector(int port, String uriEncoding, String protocolHandlerClassName, String keystore, String keyPassword, String truststore, String trustPassword, String clientAuth) {
         def httpsConnector = createConnector(port, uriEncoding, protocolHandlerClassName)
         httpsConnector.scheme = 'https'
         httpsConnector.secure = true

--- a/tomcat7x/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/Tomcat7xServer.groovy
+++ b/tomcat7x/src/main/groovy/org/gradle/api/plugins/tomcat/embedded/Tomcat7xServer.groovy
@@ -92,7 +92,7 @@ class Tomcat7xServer implements TomcatServer {
      }
 
     @Override
-    void configureHttpsConnector(int port, String uriEncoding, String protocolHandlerClassName, String keystore, String keyPassword) {
+    void configureHttpsConnector(int port, String uriEncoding, String protocolHandlerClassName, String keystore, String keyPassword, String truststore, String trustPassword, String clientAuth) {
         def httpsConnector = createConnector(protocolHandlerClassName, uriEncoding)
         httpsConnector.scheme = 'https'
         httpsConnector.secure = true
@@ -100,6 +100,9 @@ class Tomcat7xServer implements TomcatServer {
         httpsConnector.setAttribute('SSLEnabled', 'true')
         httpsConnector.setAttribute('keystoreFile', keystore)
         httpsConnector.setAttribute('keystorePass', keyPassword)
+        httpsConnector.setAttribute('truststoreFile', truststore)
+        httpsConnector.setAttribute('truststorePass', trustPassword)
+        httpsConnector.setAttribute('clientAuth', clientAuth)
         tomcat.service.addConnector httpsConnector
     }
 


### PR DESCRIPTION
Hi,

This aims to solve [issue #60](https://github.com/bmuschko/gradle-tomcat-plugin/issues/60) by introducing support for providing a trustStore and enabling clientAuth.

Hopefully the commit details and new tests are self explanatory but don't hesitate to ask if anything is unclear or if you feel anything further needs to be done in order to accept this pull request.

Cheers,

Edd
