### PR TITLE
fix gradle4 warning: Gradle now uses separate output directories

### DIFF
--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/TomcatBasePlugin.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/TomcatBasePlugin.groovy
@@ -21,6 +21,7 @@ import com.bmuschko.gradle.tomcat.tasks.TomcatRun
 import com.bmuschko.gradle.tomcat.tasks.TomcatRunWar
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.WarPlugin
 import org.gradle.api.plugins.WarPluginConvention
 
@@ -57,7 +58,10 @@ class TomcatBasePlugin implements Plugin<Project> {
                 File webAppDir = getWarConvention(project).webAppDir
                 webAppDir.exists() ? webAppDir : null
             }
-            conventionMapping.map('classesDirectory') { project.sourceSets.main.output.classesDir.exists() ? project.sourceSets.main.output.classesDir : null }
+            conventionMapping.map('classesDirectory') {
+                File acd = (project.sourceSets.main.output.classesDirs != null) ? project.sourceSets.main.output.classesDirs.first() : null
+                (acd != null && acd.exists()) ? acd : null
+            }
         }
     }
 

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/TomcatPlugin.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/TomcatPlugin.groovy
@@ -66,6 +66,7 @@ class TomcatPlugin implements Plugin<Project> {
             conventionMapping.map('ajpPort') { tomcatPluginExtension.ajpPort }
             conventionMapping.map('ajpProtocol') { tomcatPluginExtension.ajpProtocol }
             conventionMapping.map('users') { tomcatPluginExtension.users }
+            conventionMapping.map('cacheSize') { tomcatPluginExtension.cacheSize }
         }
     }
 

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/extension/TomcatPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/extension/TomcatPluginExtension.groovy
@@ -35,6 +35,7 @@ class TomcatPluginExtension {
     String httpProtocol = DEFAULT_PROTOCOL_HANDLER
     String httpsProtocol = DEFAULT_PROTOCOL_HANDLER
     String ajpProtocol = DEFAULT_AJP_PROTOCOL_HANDLER
+    Integer cacheSize = 0
     TomcatJasperConvention jasper = new TomcatJasperConvention()
     List<TomcatUser> users = []
 

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/tasks/AbstractTomcatRun.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/tasks/AbstractTomcatRun.groovy
@@ -199,6 +199,14 @@ abstract class AbstractTomcatRun extends Tomcat {
     String ajpProtocol = 'org.apache.coyote.ajp.AjpProtocol'
 
     /**
+     * Add context resources cacheSize: 0 =unchange, lt 0 =disable caching, gt 0 =max size cache
+     */
+    @Input
+    @Optional
+    Integer cacheSize = 0
+
+
+    /**
      * The list of Tomcat users. Defaults to an empty list.
      */
     @Input
@@ -307,6 +315,13 @@ abstract class AbstractTomcatRun extends Tomcat {
     protected void configureWebApplication() {
         setWebApplicationContext()
         server.createLoader(Thread.currentThread().contextClassLoader)
+
+        // FIX: large project cache warning in tomcat.
+        if (getCacheSize() > 0) {
+            server.context.resources.cacheMaxSize = getCacheSize()
+        } else if (getCacheSize() < 0) {
+            server.context.resources.cachingAllowed = false
+        }
 
         logger.info "Additional runtime resources classpath = ${getAdditionalRuntimeResources()}"
 


### PR DESCRIPTION
fix #168 

simple return `sourceSets.main.output.classesDirs` first element.
