### PR TITLE
Feature/add cacheSize config, fix tomcat log cache warning.

### DIFF
--- a/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcat8xPlusImpl.groovy
+++ b/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcat8xPlusImpl.groovy
@@ -22,6 +22,7 @@ abstract class BaseTomcat8xPlusImpl extends BaseTomcat7xPlusImpl {
         context.addServletContainerInitializer(jasperInitializer.newInstance(), null)
     }
 
+
     @Override
     void addWebappResource(File resource) {
         context.resources.createWebResourceSet(getResourceSetType('PRE'), '/WEB-INF/classes', resource.toURI().toURL(), '/')
@@ -30,5 +31,13 @@ abstract class BaseTomcat8xPlusImpl extends BaseTomcat7xPlusImpl {
     def getResourceSetType(String name) {
         Class resourceSetTypeClass = loadClass('org.apache.catalina.WebResourceRoot$ResourceSetType')
         resourceSetTypeClass.enumConstants.find { it.name() == name }
+    }
+
+    void setResourcesCacheSize(int cacheSize) {
+        if (cacheSize > 0) {
+            context.resources.cacheMaxSize = cacheSize
+        } else if (cacheSize < 0) {
+            context.resources.cachingAllowed = false
+        }
     }
 }

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/TomcatPlugin.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/TomcatPlugin.groovy
@@ -66,6 +66,7 @@ class TomcatPlugin implements Plugin<Project> {
             conventionMapping.map('ajpPort') { tomcatPluginExtension.ajpPort }
             conventionMapping.map('ajpProtocol') { tomcatPluginExtension.ajpProtocol }
             conventionMapping.map('users') { tomcatPluginExtension.users }
+            conventionMapping.map('cacheSize') { tomcatPluginExtension.cacheSize }
         }
     }
 

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/extension/TomcatPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/extension/TomcatPluginExtension.groovy
@@ -35,6 +35,7 @@ class TomcatPluginExtension {
     String httpProtocol = DEFAULT_PROTOCOL_HANDLER
     String httpsProtocol = DEFAULT_PROTOCOL_HANDLER
     String ajpProtocol = DEFAULT_AJP_PROTOCOL_HANDLER
+    Integer cacheSize = 0
     TomcatJasperConvention jasper = new TomcatJasperConvention()
     List<TomcatUser> users = []
 

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/tasks/AbstractTomcatRun.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/tasks/AbstractTomcatRun.groovy
@@ -23,6 +23,7 @@ import com.bmuschko.gradle.tomcat.internal.ssl.SSLKeyStoreImpl
 import com.bmuschko.gradle.tomcat.internal.ssl.StoreType
 import com.bmuschko.gradle.tomcat.internal.utils.ThreadContextClassLoader
 import com.bmuschko.gradle.tomcat.internal.utils.TomcatThreadContextClassLoader
+import org.codehaus.groovy.runtime.DefaultGroovyMethods
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.FileCollection
@@ -317,10 +318,12 @@ abstract class AbstractTomcatRun extends Tomcat {
         server.createLoader(Thread.currentThread().contextClassLoader)
 
         // FIX: large project cache warning in tomcat.
-        if (getCacheSize() > 0) {
-            server.context.resources.cacheMaxSize = getCacheSize()
-        } else if (getCacheSize() < 0) {
-            server.context.resources.cachingAllowed = false
+        if (getCacheSize() != 0) { // only config cacheSize when cacheSize!=0
+            if(server.metaClass.respondsTo(server, "setResourcesCacheSize", getCacheSize())){
+                server.metaClass.invokeMethod(server,"setResourcesCacheSize", getCacheSize())
+            } else {
+                logger.warn("CacheSize setting only support tomcat 8+")
+            }
         }
 
         logger.info "Additional runtime resources classpath = ${getAdditionalRuntimeResources()}"

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/tasks/AbstractTomcatRun.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/tasks/AbstractTomcatRun.groovy
@@ -199,6 +199,14 @@ abstract class AbstractTomcatRun extends Tomcat {
     String ajpProtocol = 'org.apache.coyote.ajp.AjpProtocol'
 
     /**
+     * Add context resources cacheSize: 0 =unchange, lt 0 =disable caching, gt 0 =max size cache
+     */
+    @Input
+    @Optional
+    Integer cacheSize = 0
+
+
+    /**
      * The list of Tomcat users. Defaults to an empty list.
      */
     @Input
@@ -307,6 +315,13 @@ abstract class AbstractTomcatRun extends Tomcat {
     protected void configureWebApplication() {
         setWebApplicationContext()
         server.createLoader(Thread.currentThread().contextClassLoader)
+
+        // FIX: large project cache warning in tomcat.
+        if (getCacheSize() > 0) {
+            server.context.resources.cacheMaxSize = getCacheSize()
+        } else if (getCacheSize() < 0) {
+            server.context.resources.cachingAllowed = false
+        }
 
         logger.info "Additional runtime resources classpath = ${getAdditionalRuntimeResources()}"
 


### PR DESCRIPTION
some jar like vaadin, contains java source file and other resources file. Tomcat will log warning for each file.

solve this problem: add `cacheSize ` config.

FIX: #170 

