### PR TITLE
Feature/fix gradle4 warning: Gradle now uses separate output directories

### DIFF
--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/TomcatBasePlugin.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/TomcatBasePlugin.groovy
@@ -21,6 +21,7 @@ import com.bmuschko.gradle.tomcat.tasks.TomcatRun
 import com.bmuschko.gradle.tomcat.tasks.TomcatRunWar
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.WarPlugin
 import org.gradle.api.plugins.WarPluginConvention
 
@@ -57,7 +58,10 @@ class TomcatBasePlugin implements Plugin<Project> {
                 File webAppDir = getWarConvention(project).webAppDir
                 webAppDir.exists() ? webAppDir : null
             }
-            conventionMapping.map('classesDirectory') { project.sourceSets.main.output.classesDir.exists() ? project.sourceSets.main.output.classesDir : null }
+            conventionMapping.map('classesDirectory') {
+                File acd = (project.sourceSets.main.output.classesDirs != null) ? project.sourceSets.main.output.classesDirs.first() : null
+                (acd != null && acd.exists()) ? acd : null
+            }
         }
     }
 


### PR DESCRIPTION
fix #168

simple return sourceSets.main.output.classesDirs first element.
