### PR TITLE
Feature/Defines additional web file or directories that are not provided by the web application.

### DIFF
--- a/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcat8xPlusImpl.groovy
+++ b/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcat8xPlusImpl.groovy
@@ -31,4 +31,12 @@ abstract class BaseTomcat8xPlusImpl extends BaseTomcat7xPlusImpl {
         Class resourceSetTypeClass = loadClass('org.apache.catalina.WebResourceRoot$ResourceSetType')
         resourceSetTypeClass.enumConstants.find { it.name() == name }
     }
+
+    protected void addWebappAdditionalFile(String webAppMountPoint, File file) {
+        println "\t\t设置了额外资源 ${webAppMountPoint} ${file}"
+        if (file.exists()) {
+            context.resources.createWebResourceSet(getResourceSetType('PRE'),
+                    webAppMountPoint, file.toURI().toURL(), '/')
+        }
+    }
 }

--- a/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcat8xPlusImpl.groovy
+++ b/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcat8xPlusImpl.groovy
@@ -33,7 +33,6 @@ abstract class BaseTomcat8xPlusImpl extends BaseTomcat7xPlusImpl {
     }
 
     protected void addWebappAdditionalFile(String webAppMountPoint, File file) {
-        println "\t\t设置了额外资源 ${webAppMountPoint} ${file}"
         if (file.exists()) {
             context.resources.createWebResourceSet(getResourceSetType('PRE'),
                     webAppMountPoint, file.toURI().toURL(), '/')

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/tasks/AbstractTomcatRun.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/tasks/AbstractTomcatRun.groovy
@@ -26,6 +26,7 @@ import com.bmuschko.gradle.tomcat.internal.utils.TomcatThreadContextClassLoader
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.*
 
 import java.util.concurrent.CountDownLatch
@@ -105,6 +106,15 @@ abstract class AbstractTomcatRun extends Tomcat {
      */
     @InputFiles
     Iterable<File> additionalRuntimeResources = []
+
+    /**
+     * Defines additional web file or directories that are not provided by the web application.
+     * In task TomcatRunWar, you can add src/main/webapp as liveedit web resources.
+     *
+     * exclue: WEB-INF/lib, WEB-INF/classes, WEB-INF/web.xml, META-INF/
+     */
+    @InputFiles
+    Iterable<File> additionalWebResources = []
 
     /**
      * Specifies the character encoding used to decode the URI bytes by the HTTP Connector. Defaults to "UTF-8".
@@ -301,6 +311,23 @@ abstract class AbstractTomcatRun extends Tomcat {
         }
     }
 
+    protected void addWebappAdditionalFile(String webAppMountPoint, File file) {
+        if (file.exists()) {
+            getServer().context.resources.createWebResourceSet(getResourceSetType('PRE'),
+                    webAppMountPoint, file.toURI().toURL(), '/')
+        }
+    }
+
+    static Class loadClass(String className) {
+        ClassLoader classLoader = Thread.currentThread().contextClassLoader
+        classLoader.loadClass(className)
+    }
+
+    static def getResourceSetType(String name) {
+        Class resourceSetTypeClass = loadClass('org.apache.catalina.WebResourceRoot$ResourceSetType')
+        resourceSetTypeClass.enumConstants.find { it.name() == name }
+    }
+
     /**
      * Configures web application
      */
@@ -312,6 +339,25 @@ abstract class AbstractTomcatRun extends Tomcat {
 
         getAdditionalRuntimeResources().each { file ->
             addWebappResource(file)
+        }
+
+        logger.info "Additional web resources = ${getAdditionalWebResources()}"
+        getAdditionalWebResources().each { awr ->
+            if (awr.exists()) {
+                if (awr.isFile()) {
+                    addWebappAdditionalFile("/", awr)
+                    logger.debug "\tadd web resource: /${awr.name}"
+                } else {
+                    FileTree tree = project.fileTree(dir: awr).matching {
+                        exclude "**/WEB-INF/lib", "**/WEB-INF/classes", "**/WEB-INF/web.xml", "**/META-INF/"
+                    }
+
+                    tree.visit { element ->
+                        addWebappAdditionalFile("/${element.relativePath.pathString}", element.file)
+                        logger.debug "\tadd web resource: /${element.relativePath.pathString}"
+                    }
+                }
+            }
         }
 
         server.context.reloadable = getReloadable()


### PR DESCRIPTION
Defines additional web file or directories that are not provided by the web application.

In task TomcatRunWar, you can add src/main/webapp as liveedit web resources.

exclue: WEB-INF/lib, WEB-INF/classes, WEB-INF/web.xml, META-INF/

> 
> In my multi-module project, only tomcatRunWar task work fine(has web-fragment.xml and \@WebServlet). but tomcatRunWar doesn't include src/main/webapp for  live edit. for static file change,  must restart tomcatRunWar task.
> 
> So, add a property:  Iterable<File> additionalWebResources = []
> 
> In my build.gradle:
> 

```
tomcatRunWar.each { task ->
    task.additionalWebResources << file("src/main/webapp")
}
```

> 
> Now, we can edit static file ( or jsp ), then refresh browser to view the change, like tomcatRun.
> 
> Not only src/main/webapp, we can include any path, include other modules or external project.
> 
> This patch maybe fix issus #164 and #161 
> 