### PR TITLE
Update to the latest gradle-build-action

### DIFF
--- a/.github/workflows/linux-build-release.yml
+++ b/.github/workflows/linux-build-release.yml
@@ -13,23 +13,23 @@ jobs:
         with:
           java-version: 11
       - name: Compilation
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: classes
       - name: Unit tests
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: test
       - name: Integration tests
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: integrationTest
       - name: Functional tests
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: functionalTest
       - name: Assemble artifact
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: assemble
       - name: Store artifact
@@ -39,6 +39,6 @@ jobs:
           path: build/libs/*.jar
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: publishPlugins gitPublishPush -Pgradle.publish.key=${{ secrets.PLUGIN_PORTAL_KEY }} -Pgradle.publish.secret=${{ secrets.PLUGIN_PORTAL_SECRET }} -Dorg.ajoberstar.grgit.auth.username=${{ secrets.GH_TOKEN }} -is


### PR DESCRIPTION
The action id `eskatos/gradle-command-action` has been replaced by `gradle/gradle-build-action`.
This PR switches to the new action id, and updates to test the latest `v2` version (presently `v2.0-beta.2`).