### PR TITLE
Draft: Add support for mounting additional resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ server has started. When false, this task blocks until the Tomcat server is stop
 * `ajpProtocol`: The AJP protocol handler class name to be used (defaults to `org.apache.coyote.ajp.AjpProtocol`).
 * `users`: List of users with `username`, `password` and `roles`. Used to configure tomcat with basic authentication 
 with these users.
+* `resources`: List of additional resources with `path` and `mountpoint` for serving static files.
 
 ### Example
 
@@ -268,6 +269,13 @@ tomcat {
             username = 'user2'
             password = 'abcdef'
             roles = ['manager']
+        }
+    }
+
+    resources {
+        resource {
+            path = new File(projectDir, "src/assets/vendor")
+            mountpoint = "/client"
         }
     }
 }

--- a/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcat8xPlusImpl.groovy
+++ b/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcat8xPlusImpl.groovy
@@ -27,6 +27,11 @@ abstract class BaseTomcat8xPlusImpl extends BaseTomcat7xPlusImpl {
         context.resources.createWebResourceSet(getResourceSetType('PRE'), '/WEB-INF/classes', resource.toURI().toURL(), '/')
     }
 
+    @Override
+    void addResource(Resource resource) {
+        context.resources.createWebResourceSet(getResourceSetType('PRE'), resource.mountpoint, resource.path.toURI().toURL(), '/')
+    }
+
     def getResourceSetType(String name) {
         Class resourceSetTypeClass = loadClass('org.apache.catalina.WebResourceRoot$ResourceSetType')
         resourceSetTypeClass.enumConstants.find { it.name() == name }

--- a/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcatServerImpl.groovy
+++ b/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcatServerImpl.groovy
@@ -41,6 +41,11 @@ abstract class BaseTomcatServerImpl implements TomcatServer {
     }
 
     @Override
+    void addResource(Resource resource) {
+        // TODO: how to implement this here for Tomcat 7x?
+    }
+
+    @Override
     void addStartUpLifecycleListener(CountDownLatch startupBarrier, boolean daemon) {
         def afterStartEventLifecycleListener = java.lang.reflect.Proxy.newProxyInstance(Thread.currentThread().contextClassLoader,
                 [loadClass('org.apache.catalina.LifecycleListener')] as Class[], new AfterStartEventLifecycleListener(startupBarrier, daemon))

--- a/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/Resource.groovy
+++ b/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/Resource.groovy
@@ -1,0 +1,12 @@
+package com.bmuschko.gradle.tomcat.embedded
+
+import groovy.transform.Canonical
+
+/**
+ * Defines an additional resource.
+ */
+@Canonical
+class Resource implements Serializable {
+    File path
+    String mountpoint
+}

--- a/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/TomcatServer.groovy
+++ b/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/TomcatServer.groovy
@@ -38,6 +38,7 @@ interface TomcatServer {
     void configureUser(TomcatUser user)
     void setConfigFile(URL configFile)
     void addWebappResource(File resource)
+    void addResource(Resource resource)
     void addStartUpLifecycleListener(CountDownLatch startupBarrier, boolean daemon)
     void start()
     void stop()

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/TomcatPlugin.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/TomcatPlugin.groovy
@@ -66,6 +66,7 @@ class TomcatPlugin implements Plugin<Project> {
             conventionMapping.map('ajpPort') { tomcatPluginExtension.ajpPort }
             conventionMapping.map('ajpProtocol') { tomcatPluginExtension.ajpProtocol }
             conventionMapping.map('users') { tomcatPluginExtension.users }
+            conventionMapping.map('resources') { tomcatPluginExtension.resources }
         }
     }
 

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/extension/TomcatPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/extension/TomcatPluginExtension.groovy
@@ -15,6 +15,7 @@
  */
 package com.bmuschko.gradle.tomcat.extension
 
+import com.bmuschko.gradle.tomcat.embedded.Resource
 import com.bmuschko.gradle.tomcat.embedded.TomcatUser
 
 /**
@@ -37,6 +38,7 @@ class TomcatPluginExtension {
     String ajpProtocol = DEFAULT_AJP_PROTOCOL_HANDLER
     TomcatJasperConvention jasper = new TomcatJasperConvention()
     List<TomcatUser> users = []
+    List<Resource> resources = []
 
     def jasper(Closure closure) {
         closure.resolveStrategy = Closure.DELEGATE_FIRST
@@ -55,6 +57,20 @@ class TomcatPluginExtension {
         TomcatUser user = new TomcatUser()
         closure.delegate = user
         users << user
+        closure()
+    }
+
+    def resources(Closure closure) {
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        closure.delegate = resources
+        closure()
+    }
+
+    def resource(Closure closure) {
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        Resource resource = new Resource()
+        closure.delegate = resource
+        resources << resource
         closure()
     }
 }

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/tasks/AbstractTomcatRun.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/tasks/AbstractTomcatRun.groovy
@@ -15,6 +15,7 @@
  */
 package com.bmuschko.gradle.tomcat.tasks
 
+import com.bmuschko.gradle.tomcat.embedded.Resource
 import com.bmuschko.gradle.tomcat.embedded.TomcatUser
 import com.bmuschko.gradle.tomcat.embedded.factory.TomcatServerFactory
 import com.bmuschko.gradle.tomcat.internal.ShutdownMonitor
@@ -205,6 +206,13 @@ abstract class AbstractTomcatRun extends Tomcat {
     @Optional
     List<TomcatUser> users = []
 
+    /**
+     * A list of additional resources to serve. Defaults to an empty list.
+     */
+    @Input
+    @Optional
+    List<Resource> resources = []
+
     @Internal
     def server
 
@@ -338,6 +346,10 @@ abstract class AbstractTomcatRun extends Tomcat {
 
             getUsers().each { TomcatUser user ->
                 server.configureUser(user)
+            }
+
+            getResources().each { Resource resource ->
+                server.addResource(resource)
             }
 
             if(getEnableSSL()) {


### PR DESCRIPTION
I added the plugin to a web app I work on. Works nicely, I just found I couldn't configure something that I usually configure for development in Eclipse and deployment as WAR files: additional resources that are mounted at a specific location of the web app.

I usually use this to make client side JavaScript/CSS libraries available at a specific location and also serve static files generated by other Gradle plugins.