### PR TITLE
Add support to set the AJP optional secret.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### Version 2.8.0 (UNRELEASED)
+
+* Add option to set the ajp secret. 
+
 ### Version 2.7.0 (June 29, 2021)
 
 * Add jspFiles and failOnError parameter for passing to the jspc ant task - [Pull Request 195](https://github.com/bmuschko/gradle-tomcat-plugin/pull/195).

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = 'com.bmuschko'
-    version = '2.7.0'
+    version = '2.8.0'
 }
 
 subprojects {

--- a/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcat7xPlusImpl.groovy
+++ b/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcat7xPlusImpl.groovy
@@ -96,7 +96,7 @@ abstract class BaseTomcat7xPlusImpl extends BaseTomcatServerImpl {
         httpsConnector
     }
 
-    private createConnector(String protocolHandlerClassName, String uriEncoding) {
+    def createConnector(String protocolHandlerClassName, String uriEncoding) {
         Class connectorClass = loadClass('org.apache.catalina.connector.Connector')
         Constructor constructor = connectorClass.getConstructor([String] as Class[])
         def connector = constructor.newInstance([protocolHandlerClassName] as Object[])

--- a/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcat9xPlusImpl.groovy
+++ b/embedded/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/BaseTomcat9xPlusImpl.groovy
@@ -1,0 +1,14 @@
+package com.bmuschko.gradle.tomcat.embedded
+/**
+ * Base Tomcat 8x and higher implementation.
+ */
+abstract class BaseTomcat9xPlusImpl extends BaseTomcat8xPlusImpl {
+    @Override
+    void configureAjpConnector(int port, String uriEncoding, String protocolHandlerClassName) {
+        def ajpConnector = createConnector(protocolHandlerClassName, uriEncoding)
+        ajpConnector.port = port
+        def ajpProtocol = ajpConnector.getProtocolHandler()
+        ajpProtocol.secretRequired = false
+        tomcat.service.addConnector ajpConnector
+    }
+}

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/TomcatPlugin.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/TomcatPlugin.groovy
@@ -65,6 +65,8 @@ class TomcatPlugin implements Plugin<Project> {
             conventionMapping.map('httpsProtocol') { tomcatPluginExtension.httpsProtocol }
             conventionMapping.map('ajpPort') { tomcatPluginExtension.ajpPort }
             conventionMapping.map('ajpProtocol') { tomcatPluginExtension.ajpProtocol }
+            conventionMapping.map('ajpSecretRequired') { tomcatPluginExtension.ajpSecretRequired }
+            conventionMapping.map('ajpSecret') { tomcatPluginExtension.ajpSecret }
             conventionMapping.map('users') { tomcatPluginExtension.users }
         }
     }

--- a/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/extension/TomcatPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/bmuschko/gradle/tomcat/extension/TomcatPluginExtension.groovy
@@ -35,6 +35,8 @@ class TomcatPluginExtension {
     String httpProtocol = DEFAULT_PROTOCOL_HANDLER
     String httpsProtocol = DEFAULT_PROTOCOL_HANDLER
     String ajpProtocol = DEFAULT_AJP_PROTOCOL_HANDLER
+    Boolean ajpSecretRequired = Boolean.TRUE
+    String ajpSecret
     TomcatJasperConvention jasper = new TomcatJasperConvention()
     List<TomcatUser> users = []
 

--- a/plugin/src/test/groovy/com/bmuschko/gradle/tomcat/TomcatPluginExtensionTest.groovy
+++ b/plugin/src/test/groovy/com/bmuschko/gradle/tomcat/TomcatPluginExtensionTest.groovy
@@ -35,5 +35,7 @@ class TomcatPluginExtensionTest extends Specification {
         pluginExtension.httpProtocol == TomcatPluginExtension.DEFAULT_PROTOCOL_HANDLER
         pluginExtension.httpsProtocol == TomcatPluginExtension.DEFAULT_PROTOCOL_HANDLER
         pluginExtension.ajpProtocol == TomcatPluginExtension.DEFAULT_AJP_PROTOCOL_HANDLER
+        pluginExtension.ajpSecretRequired == Boolean.TRUE
+        !pluginExtension.ajpSecret
     }
 }

--- a/tomcat9x/build.gradle
+++ b/tomcat9x/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    def tomcatVersion = '9.0.1'
+    def tomcatVersion = '9.0.68'
 
     implementation project(':embedded'),
             "org.apache.tomcat:tomcat-catalina:${tomcatVersion}",

--- a/tomcat9x/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/Tomcat9xServer.groovy
+++ b/tomcat9x/src/main/groovy/com/bmuschko/gradle/tomcat/embedded/Tomcat9xServer.groovy
@@ -18,7 +18,7 @@ package com.bmuschko.gradle.tomcat.embedded
 /**
  * Tomcat 9x server implementation.
  */
-class Tomcat9xServer extends BaseTomcat8xPlusImpl {
+class Tomcat9xServer extends BaseTomcat9xPlusImpl {
     @Override
     TomcatVersion getVersion() {
         TomcatVersion.VERSION_9_0_X


### PR DESCRIPTION
Solves the issue (https://github.com/bmuschko/gradle-tomcat-plugin/issues/196) mentioning the ajp secret which is required by default since tomcat version 9.0.31.